### PR TITLE
Create pyp-question-template.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/pyp-question-template.md
+++ b/.github/ISSUE_TEMPLATE/pyp-question-template.md
@@ -1,0 +1,17 @@
+---
+name: PYP Question Template
+about: Template to post questions related to the past year papers of CS2030
+title: ''
+labels: ":thinking: PYP"
+assignees: ''
+
+---
+
+# Source
+Put the year/semester and the question number
+
+## Description 
+Describe the problem and code snippets if necessary 
+
+## Screenshots (if any): 
+Insert Images here if necessary


### PR DESCRIPTION
This was a follow-up from the previous semester, where PYP questions in the forum remained indistinguishable. This pull request should resolve it.